### PR TITLE
Add getInvoiceMarkup function to Client.php

### DIFF
--- a/src/AutotaskObjects/InvoiceMarkup.php
+++ b/src/AutotaskObjects/InvoiceMarkup.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * InvoiceMarkup Class, used to run getInvoiceMarkup
+ *
+ */
+
+namespace ATWS\AutotaskObjects;
+
+
+class InvoiceMarkup
+{
+    public $InvoiceId;
+    public $Format;
+}

--- a/src/Client.php
+++ b/src/Client.php
@@ -247,5 +247,12 @@ class Client extends \SoapClient
     {
         return $this->__soapCall($method, $params);
     }
+        public function getInvoiceMarkup($invoiceId, $type)
+    {
+       $obj = new AutotaskObjects\InvoiceMarkup;
+        $obj->InvoiceId = (int)$invoiceId;
+        $obj->Format = $type;
+        return $this->_call('GetInvoiceMarkup', array($obj));
+    }
     // @codeCoerageIgnoreEnd
 }

--- a/src/Client.php
+++ b/src/Client.php
@@ -70,6 +70,7 @@ class Client extends \SoapClient
         'InventoryLocation'                 => 'ATWS\AutotaskObjects\InventoryLocation',
         'InventoryTransfer'                 => 'ATWS\AutotaskObjects\InventoryTransfer',
         'Invoice'                           => 'ATWS\AutotaskObjects\Invoice',
+        'InvoiceMarkup'                     => 'ATWS\AutotaskObjects\InvoiceMarkup',
         'InvoiceTemplate'                   => 'ATWS\AutotaskObjects\InvoiceTemplate',
         'Opportunity'                       => 'ATWS\AutotaskObjects\Opportunity',
         'PaymentTerm'                       => 'ATWS\AutotaskObjects\PaymentTerm',
@@ -237,6 +238,14 @@ class Client extends \SoapClient
     {
         return $this->_call('getThresholdAndUsageInfo');
     }
+    
+    public function getInvoiceMarkup($invoiceId, $type)
+    {
+        $invoiceMarkup = new AutotaskObjects\InvoiceMarkup();
+        $invoiceMarkup->InvoiceId = (int)$invoiceId;
+        $invoiceMarkup->Format = $type;
+        return $this->_call('GetInvoiceMarkup', array($invoiceMarkup));
+    }
 
     public function __doRequest($request, $location, $action, $version, $one_way = 0)
     {
@@ -246,13 +255,6 @@ class Client extends \SoapClient
     private function _call($method, $params = array())
     {
         return $this->__soapCall($method, $params);
-    }
-        public function getInvoiceMarkup($invoiceId, $type)
-    {
-       $obj = new AutotaskObjects\InvoiceMarkup;
-        $obj->InvoiceId = (int)$invoiceId;
-        $obj->Format = $type;
-        return $this->_call('GetInvoiceMarkup', array($obj));
     }
     // @codeCoerageIgnoreEnd
 }


### PR DESCRIPTION
This function uses the InvoiceMarkup class to enable the use of the GetInvoiceMarkup API function.

It is used like so:
$markup = $client->getInvoiceMarkup($invoiceId, $type);
$output = $markup->GetInvoiceMarkupResult;
echo $output;

$invoiceId should be the ID (not invoice number) of the invoice
$type can be either HTML or XML depending on your needs

In a different proposal, I'll add InvoiceMarkup.php to AUtotaskObjects