### PR TITLE
Removed unneeded variable ($id) from objects

### DIFF
--- a/src/AutotaskObjects/AccountTeam.php
+++ b/src/AutotaskObjects/AccountTeam.php
@@ -4,6 +4,5 @@ namespace ATWS\AutotaskObjects;
 class AccountTeam extends Entity
 {
     public $AccountID;
-    public $ID;
     public $ResourceID;
 }

--- a/src/AutotaskObjects/AdditionalInvoiceFieldValue.php
+++ b/src/AutotaskObjects/AdditionalInvoiceFieldValue.php
@@ -5,6 +5,5 @@ class AdditionalInvoiceFieldValue extends Entity
 {
     public $AdditionalInvoiceFieldID;
     public $FieldValue;
-    public $Id;
     public $InvoiceBatchID;
 }

--- a/src/AutotaskObjects/Department.php
+++ b/src/AutotaskObjects/Department.php
@@ -4,7 +4,6 @@ namespace ATWS\AutotaskObjects;
 class Department extends Entity
 {
     public $Description;
-    public $Id;
     public $Name;
     public $Number;
     public $PrimaryLocationID;

--- a/src/AutotaskObjects/InvoiceMarkup.php
+++ b/src/AutotaskObjects/InvoiceMarkup.php
@@ -1,11 +1,5 @@
 <?php
-/**
- * InvoiceMarkup Class, used to run getInvoiceMarkup
- *
- */
-
 namespace ATWS\AutotaskObjects;
-
 
 class InvoiceMarkup
 {

--- a/src/AutotaskObjects/InvoiceTemplate.php
+++ b/src/AutotaskObjects/InvoiceTemplate.php
@@ -13,7 +13,6 @@ class InvoiceTemplate extends Entity
     public $DisplayTaxCategorySuperscripts;
     public $DisplayZeroAmountRecurringServicesAndBundles;
     public $GroupBy;
-    public $Id;
     public $ItemizeItemsInEachGroup;
     public $ItemizeServicesAndBundles;
     public $Name;

--- a/src/AutotaskObjects/PaymentTerm.php
+++ b/src/AutotaskObjects/PaymentTerm.php
@@ -5,7 +5,6 @@ class PaymentTerm extends Entity
 {
     public $Active;
     public $Description;
-    public $Id;
     public $Name;
     public $PaymentDueInDays;
 }

--- a/src/AutotaskObjects/ResourceRole.php
+++ b/src/AutotaskObjects/ResourceRole.php
@@ -4,7 +4,6 @@ namespace ATWS\AutotaskObjects;
 class ResourceRole extends Entity
 {
     public $DepartmentID;
-    public $Id;
     public $QueueID;
     public $ResourceID;
     public $RoleID;

--- a/src/AutotaskObjects/ServiceBundleService.php
+++ b/src/AutotaskObjects/ServiceBundleService.php
@@ -3,7 +3,6 @@ namespace ATWS\AutotaskObjects;
 
 class ServiceBundleService extends Entity
 {
-    public $Id;
     public $ServiceBundleID;
     public $ServiceID;
 }

--- a/src/AutotaskObjects/TaskPredecessor.php
+++ b/src/AutotaskObjects/TaskPredecessor.php
@@ -3,7 +3,6 @@ namespace ATWS\AutotaskObjects;
 
 class TaskPredecessor extends Entity
 {
-    public $Id;
     public $LagDays;
     public $PredecessorTaskID;
     public $SuccessorTaskID;

--- a/src/AutotaskObjects/TaskSecondaryResource.php
+++ b/src/AutotaskObjects/TaskSecondaryResource.php
@@ -3,7 +3,6 @@ namespace ATWS\AutotaskObjects;
 
 class TaskSecondaryResource extends Entity
 {
-    public $Id;
     public $ResourceID;
     public $RoleID;
     public $TaskID;

--- a/src/AutotaskObjects/TicketSecondaryResource.php
+++ b/src/AutotaskObjects/TicketSecondaryResource.php
@@ -3,7 +3,6 @@ namespace ATWS\AutotaskObjects;
 
 class TicketSecondaryResource extends Entity
 {
-    public $Id;
     public $ResourceID;
     public $RoleID;
     public $TicketID;

--- a/src/AutotaskObjects/UserDefinedFieldListItem.php
+++ b/src/AutotaskObjects/UserDefinedFieldListItem.php
@@ -4,7 +4,6 @@ namespace ATWS\AutotaskObjects;
 class UserDefinedFieldListItem extends Entity
 {
     public $CreateDate;
-    public $Id;
     public $UdfFieldId;
     public $ValueForDisplay;
     public $ValueForExport;


### PR DESCRIPTION
11 AutotaskObjects had a $Id variable which caused two id variables ($Id & $id) to be returned that were removed.
Removed whitespace and comments from InvoiceTemplate to standardize with the rest of the files.