### PR TITLE
Fix the 6 redefined variables and missing closing }

### DIFF
--- a/src/AutotaskObjects/AllocationCode.php
+++ b/src/AutotaskObjects/AllocationCode.php
@@ -20,7 +20,5 @@ class AllocationCode extends Entity
     public $Taxable;
     public $TaxCategoryID;
     public $Type;
-    public $UnitCost;
-    public $UnitPrice;
     public $UseType;
 }

--- a/src/AutotaskObjects/ContractCost.php
+++ b/src/AutotaskObjects/ContractCost.php
@@ -17,7 +17,6 @@ class ContractCost extends Entity
     public $Billed;
     public $ContractServiceBundleID;
     public $ContractServiceID;
-    public $CostType;
     public $CreateDate;
     public $CreatorResourceID;
     public $Description;

--- a/src/AutotaskObjects/ContractServiceUnit.php
+++ b/src/AutotaskObjects/ContractServiceUnit.php
@@ -16,3 +16,4 @@ class ContractServiceUnit extends Entity
     public $InternalCurrencyPrice;
     public $Price;
     public $VendorAccountID;
+}

--- a/src/AutotaskObjects/InstalledProduct.php
+++ b/src/AutotaskObjects/InstalledProduct.php
@@ -51,7 +51,6 @@ class InstalledProduct extends Entity
     public $NumberOfUsers;
     public $ParentInstalledProductID;
     public $PerUseCost;
-    public $ProductID;
     public $ReferenceNumber;
     public $ReferenceTitle;
     public $SerialNumber;

--- a/src/AutotaskObjects/Invoice.php
+++ b/src/AutotaskObjects/Invoice.php
@@ -14,7 +14,6 @@ class Invoice extends Entity
     public $CreatorResourceID;
     public $DueDate;
     public $FromDate;
-    public $InvoiceDateTime;
     public $InvoiceEditorTemplateID;
     public $InvoiceNumber;
     public $InvoiceTotal;

--- a/src/AutotaskObjects/InvoiceTemplate.php
+++ b/src/AutotaskObjects/InvoiceTemplate.php
@@ -30,6 +30,5 @@ class InvoiceTemplate extends Entity
     public $CoveredByRecurringServiceFixedPricePerTicketContractLabel;
     public $CurrencyNegativeFormat;
     public $CurrencyPositiveFormat;
-    public $DateFormat;
     public $RateCostExpression;
 }


### PR DESCRIPTION
Found these programmatically using the following script

```
<?php
require_once __DIR__ . '/src/autoload.php';

$files = scandir(__DIR__ . '/src/AutotaskObjects');

foreach ($files as $file) {
    if ($file === '.' || $file === '..') {
        continue;
    }
    $classname = "\\ATWS\\AutotaskObjects\\" . str_replace('.php', '', $file);

    try {
        $class = new $classname();
    } catch (\Exception $e) {
        print($e->getMessage() . "\n");
    }
}
```