### PR TITLE
Added the required field 'id' to the base class 'entity'

### DIFF
--- a/src/AutotaskObjects/Entity.php
+++ b/src/AutotaskObjects/Entity.php
@@ -4,6 +4,7 @@ namespace ATWS\AutotaskObjects;
 class Entity
 {
     // Required
+    public $id;
     public $Fields;
     public $UserDefinedFields;
 }


### PR DESCRIPTION
The 'id' field is required on **all** Autotask Entities. I believe it makes sense to add it to the base entity class instead of each classes individually.