### PR TITLE
Make __doRequest compatible with parent

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -343,7 +343,7 @@ class Client extends \SoapClient
         return $this->_call('GetInvoiceMarkup', array($invoiceMarkup));
     }
 
-    public function __doRequest($request, $location, $action, $version, $oneWay = 0): string
+    public function __doRequest($request, $location, $action, $version, $oneWay = 0): ?string
     {
         if (strpos($action, 'getZoneInfo') === false &&
             $this->version >= 1.6 &&


### PR DESCRIPTION
From the documentation, https://www.php.net/manual/en/soapclient.dorequest.php returned value may be string or null. When this code is running with PHP 8.1 and null is returned the error `PHP Fatal error:  Uncaught TypeError: ATWS\Client::__doRequest(): Return value must be of type string, null returned in /*******/vendor/opendns/autotask-php/src/Client.php:355` occurs.