### PR TITLE
Fix PHP 8.2 deprecated issues

### DIFF
--- a/get_attachment_example.php
+++ b/get_attachment_example.php
@@ -1,4 +1,4 @@
- <?php
+<?php
 require_once __DIR__ . '/autoload.php';
 
 use \ATWS;
@@ -7,13 +7,13 @@ use \ATWS\AutotaskObjects;
 $username = 'INSERT USERNAME HERE';
 $password = 'INSERT PASSWORD HERE';
 
-$postAuthOpts = array(
-    'login' => $username,
+$postAuthOpts = [
+    'login'    => $username,
     'password' => $password,
-    'trace' => 1,   // Allows us to debug by getting the XML requests sent
-);
+    'trace'    => 1,   // Allows us to debug by getting the XML requests sent
+];
 
-$opts = array('trace' => 1);
+$opts = ['trace' => 1];
 $authWsdl = 'https://webservices.autotask.net/atservices/1.5/atws.wsdl';
 $client = new ATWS\Client($authWsdl, $opts);
 $zoneInfo = $client->getZoneInfo($username);

--- a/src/AutotaskObjects/CreateParam.php
+++ b/src/AutotaskObjects/CreateParam.php
@@ -6,6 +6,6 @@ class CreateParam
     public $Entities;
 
     public function __construct($param) {
-        $this->Entities = array($param);
+        $this->Entities = [$param];
     }
 }

--- a/src/AutotaskObjects/DeleteParam.php
+++ b/src/AutotaskObjects/DeleteParam.php
@@ -6,6 +6,6 @@ class DeleteParam
     public $Entities;
 
     public function __construct($param) {
-        $this->Entities = array($param);
+        $this->Entities = [$param];
     }
 }

--- a/src/AutotaskObjects/Query.php
+++ b/src/AutotaskObjects/Query.php
@@ -12,7 +12,7 @@ class Query
     public function __construct($entity)
     {
         $this->entity = $entity;
-        $this->clauses = array();
+        $this->clauses = [];
     }
 
     public function addField(QueryField $field)

--- a/src/AutotaskObjects/Query.php
+++ b/src/AutotaskObjects/Query.php
@@ -3,6 +3,7 @@ namespace ATWS\AutotaskObjects;
 
 class Query
 {
+    public $entity;
     public $clauses;
     public $query;
     public $queryField;

--- a/src/AutotaskObjects/QueryCondition.php
+++ b/src/AutotaskObjects/QueryCondition.php
@@ -8,7 +8,7 @@ class QueryCondition
 
     public function __construct($operator = null)
     {
-        $this->clauses = array();
+        $this->clauses = [];
 
         $this->operator = $operator;
 

--- a/src/AutotaskObjects/QueryField.php
+++ b/src/AutotaskObjects/QueryField.php
@@ -3,6 +3,7 @@ namespace ATWS\AutotaskObjects;
 
 class QueryField
 {
+    public $isUDF;
     public $name;
     public $expressions;
 

--- a/src/AutotaskObjects/QueryField.php
+++ b/src/AutotaskObjects/QueryField.php
@@ -11,7 +11,7 @@ class QueryField
     {
         $this->name = $name;
         $this->isUDF = $isUDF;
-        $this->expressions = array();
+        $this->expressions = [];
     }
 
     public function addExpression($op, $value)

--- a/src/AutotaskObjects/QueryFieldExpression.php
+++ b/src/AutotaskObjects/QueryFieldExpression.php
@@ -7,7 +7,7 @@ class QueryFieldExpression
     public $op;
     public $value;
 
-    public static $validOperators = array(
+    public static $validOperators = [
         'equals',
         'notequal',
         'greaterthan',
@@ -23,7 +23,7 @@ class QueryFieldExpression
         'like',
         'notlike',
         'soundslike',
-    );
+    ];
 
     public function __construct($op, $value)
     {

--- a/src/AutotaskObjects/UpdateParam.php
+++ b/src/AutotaskObjects/UpdateParam.php
@@ -6,6 +6,6 @@ class UpdateParam
     public $Entities;
 
     public function __construct($param) {
-        $this->Entities = array($param);
+        $this->Entities = [$param];
     }
 }

--- a/src/Client.php
+++ b/src/Client.php
@@ -8,7 +8,7 @@ class Client extends \SoapClient
     protected $version;
     protected $integrationCode;
 
-    public static $classMap = array(
+    public static $classMap = [
         'Account'                           => 'ATWS\AutotaskObjects\Account',
         'AccountAlert'                      => 'ATWS\AutotaskObjects\AccountAlert',
         'AccountLocation'                   => 'ATWS\AutotaskObjects\AccountLocation',
@@ -169,10 +169,10 @@ class Client extends \SoapClient
         'UserDefinedFieldDefinition'        => 'ATWS\AutotaskObjects\UserDefinedFieldDefinition',
         'UserDefinedFieldListItem'          => 'ATWS\AutotaskObjects\UserDefinedFieldListItem',
         'WorkTypeModifier'                  => 'ATWS\AutotaskObjects\WorkTypeModifier',
-    );
+    ];
 
     // @codeCoverageIgnoreStart
-    public function __construct($wsdl, $soapOpts = array(), $integrationCode = null)
+    public function __construct($wsdl, $soapOpts = [], $integrationCode = null)
     {
         foreach (static::$classMap as $external => $internal) {
             if (!isset($soapOpts['classmap'][$external])) {
@@ -196,9 +196,7 @@ class Client extends \SoapClient
         $header = new \SOAPHeader(
             'http://autotask.net/ATWS/v' . str_replace('.', '_', $this->version) .'/',
             'AutotaskIntegrations',
-            array(
-                'IntegrationCode' => $code,
-            )
+            ['IntegrationCode' => $code]
         );
 
         $this->__setSoapHeaders($header);
@@ -212,10 +210,7 @@ class Client extends \SoapClient
         $header = new \SOAPHeader(
             'http://autotask.net/ATWS/v' . str_replace('.', '_', $this->version) .'/',
             'AutotaskIntegrations',
-            array(
-                'IntegrationCode' => $this->integrationCode,
-                'ImpersonateAsResourceID' => $resourceId
-            )
+            ['IntegrationCode' => $this->integrationCode, 'ImpersonateAsResourceID' => $resourceId]
         );
         $this->__setSoapHeaders($header);
         return $this;
@@ -224,13 +219,13 @@ class Client extends \SoapClient
     public function getZoneInfo($username)
     {
         $zoneInfoObject = new AutotaskObjects\ZoneInfo($username);
-        return $this->_call('getZoneInfo', array($zoneInfoObject));
+        return $this->_call('getZoneInfo', [$zoneInfoObject]);
     }
 
     public function create(AutotaskObjects\Entity $obj)
     {
         $params = new AutotaskObjects\CreateParam($obj);
-        return $this->_call('create', array($params));
+        return $this->_call('create', [$params]);
     }
 
     public function bulkCreate(array $objs)
@@ -246,13 +241,13 @@ class Client extends \SoapClient
                 $createObjs->Entities[] = $obj;
             }
         }
-        return $this->_call('create', array($createObjs));
+        return $this->_call('create', [$createObjs]);
     }
 
     public function update(AutotaskObjects\Entity $obj)
     {
         $params = new AutotaskObjects\UpdateParam($obj);
-        return $this->_call('update', array($params));
+        return $this->_call('update', [$params]);
     }
 
     public function bulkUpdate(array $objs)
@@ -261,7 +256,7 @@ class Client extends \SoapClient
             throw new \Exception('You can only execute a bulk update on a max of 200 objects per request');
         }
         $updateObjs = null;
-        $calls = array();
+        $calls = [];
         foreach ($objs as $obj) {
             if (!$updateObjs) {
                 $updateObjs = new AutotaskObjects\UpdateParam($obj);
@@ -269,13 +264,13 @@ class Client extends \SoapClient
                 $updateObjs->Entities[] = $obj;
             }
         }
-        return $this->_call('update', array($updateObjs));
+        return $this->_call('update', [$updateObjs]);
     }
 
     public function delete(AutotaskObjects\Entity $obj)
     {
         $params = new AutotaskObjects\DeleteParam($obj);
-        return $this->_call('delete', array($params));
+        return $this->_call('delete', [$params]);
     }
 
     public function bulkDelete(array $objs)
@@ -284,7 +279,7 @@ class Client extends \SoapClient
             throw new \Exception('You can only execute a bulk delete on a max of 200 objects per request');
         }
         $deleteObjs = null;
-        $calls = array();
+        $calls = [];
         foreach ($objs as $obj) {
             if (!$deleteObjs) {
                 $deleteObjs = new AutotaskObjects\DeleteParam($obj);
@@ -292,37 +287,37 @@ class Client extends \SoapClient
                 $deleteObjs->Entities[] = $obj;
             }
         }
-        return $this->_call('delete', array($deleteObjs));
+        return $this->_call('delete', [$deleteObjs]);
     }
 
     public function GetAttachment(AutotaskObjects\Entity $obj)
     {
         $params = new AutotaskObjects\GetAttachment($obj);
-        return $this->_call('GetAttachment', array($params));
+        return $this->_call('GetAttachment', [$params]);
     }
 
     public function CreateAttachment(AutotaskObjects\Entity $obj)
     {
         $params = new AutotaskObjects\CreateAttachment($obj);
-        return $this->_call('CreateAttachment', array($params));
+        return $this->_call('CreateAttachment', [$params]);
     }
 
     public function query(AutotaskObjects\Query $obj)
     {
         $obj->asXml();
-        return $this->_call('query', array($obj));
+        return $this->_call('query', [$obj]);
     }
 
     public function getUDFInfo($type)
     {
         $param = new AutotaskObjects\UDFParam($type);
-        return $this->_call('getUDFInfo', array($param));
+        return $this->_call('getUDFInfo', [$param]);
     }
 
     public function getFieldInfo($type)
     {
         $fieldInfo = new AutotaskObjects\FieldInfo($type);
-        return $this->_call('getFieldInfo', array($fieldInfo));
+        return $this->_call('getFieldInfo', [$fieldInfo]);
     }
 
     public function getEntityInfo()
@@ -340,7 +335,7 @@ class Client extends \SoapClient
         $invoiceMarkup = new AutotaskObjects\InvoiceMarkup();
         $invoiceMarkup->InvoiceId = (int)$invoiceId;
         $invoiceMarkup->Format = $type;
-        return $this->_call('GetInvoiceMarkup', array($invoiceMarkup));
+        return $this->_call('GetInvoiceMarkup', [$invoiceMarkup]);
     }
 
     public function __doRequest($request, $location, $action, $version, $oneWay = 0): ?string
@@ -355,7 +350,7 @@ class Client extends \SoapClient
         return parent::__doRequest($request, $location, $action, $version, $oneWay);
     }
 
-    private function _call($method, $params = array())
+    private function _call($method, $params = [])
     {
         return $this->__soapCall($method, $params);
     }

--- a/ticket_create_example.php
+++ b/ticket_create_example.php
@@ -5,6 +5,7 @@
 require_once __DIR__ . '/src/autoload.php';
 
 // Edit these variables to get this example to work for you
+$accountId = '<YOUR ACCOUNT ID>';
 $username = '<YOUR USERNAME>';
 $password = '<YOUR PASSWORD>';
 
@@ -15,7 +16,7 @@ $integrationCode = '<YOUR INTEGRATION CODE>';
 $ticket = new ATWS\AutotaskObjects\Ticket();
 // Set required fields
 $ticket->id= 0;     // Set to 0 for create, or a ticket id for update
-$ticket->AccountID = ;
+$ticket->AccountID = $accountId;
 $ticket->DueDateTime = '2018-12-17';
 $ticket->Title = 'Test Ticket';
 $ticket->Status = 1;
@@ -31,15 +32,15 @@ $ticket->Priority = 1;
 // End Edit Region
 
 $authWsdl = 'https://webservices.autotask.net/atservices/1.5/atws.wsdl';
-$opts = array('trace' => 1);
+$opts = ['trace' => 1];
 $client = new ATWS\Client($authWsdl, $opts);
 $zoneInfo = $client->getZoneInfo($username);
 
-$authOpts = array(
-    'login' => $username,
+$authOpts = [
+    'login'    => $username,
     'password' => $password,
-    'trace' => 1,   // Allows us to debug by getting the XML requests sent
-);
+    'trace'    => 1,   // Allows us to debug by getting the XML requests sent
+];
 $wsdl = str_replace('.asmx', '.wsdl', $zoneInfo->getZoneInfoResult->URL);
 $client = new ATWS\Client($wsdl, $authOpts);
 $client->setIntegrationCode($integrationCode);

--- a/udf_query_example.php
+++ b/udf_query_example.php
@@ -13,17 +13,17 @@ $password = '<YOUR PASSWORD>';
 // End Edit Region
 
 $authWsdl = 'https://webservices.autotask.net/atservices/1.5/atws.wsdl';
-$opts = array('trace' => 1);
+$opts = ['trace' => 1];
 $client = new ATWS\Client($authWsdl, $opts);
 $zoneInfo = $client->getZoneInfo($username);
 
 print_r($zoneInfo);
 
-$authOpts = array(
-    'login' => $username,
+$authOpts = [
+    'login'    => $username,
     'password' => $password,
-    'trace' => 1,   // Allows us to debug by getting the XML requests sent
-);
+    'trace'    => 1,   // Allows us to debug by getting the XML requests sent
+];
 $wsdl = str_replace('.asmx', '.wsdl', $zoneInfo->getZoneInfoResult->URL);
 $client = new ATWS\Client($wsdl, $authOpts);
 


### PR DESCRIPTION
Fixed use of dynamic properties which is deprecated in PHP 8.2. In addition, changed array syntax from long to short.